### PR TITLE
Create README.md with a link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# FParsec-Pipes: making FParsec parsers even more concise and consistent
+
+FParsec is an F# library for writing parsers. This library extends [FParsec][1]
+with a new set of combinators, which I believe make it even easier to translate
+from a formal grammar like [EBNF][2] to F# parsing code and end up with a fast,
+highly readable parser.
+
+The documentation is located at http://rspeele.github.io/FParsec-Pipes/Intro.html.
+
+[1]: http://www.quanttec.com/fparsec/
+[2]: https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_Form


### PR DESCRIPTION
There was no link to the documentation from the Github repo page. This short README.md file adds that.