### PR TITLE
Target netstandard1.6 and net45

### DIFF
--- a/FParsec-Pipes-Test/FParsec-Pipes-Test.fsproj
+++ b/FParsec-Pipes-Test/FParsec-Pipes-Test.fsproj
@@ -1,8 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
     <RootNamespace>FParsec_Pipes_Test</RootNamespace>
+
+    <!-- https://github.com/Microsoft/vstest/issues/1764 -->
+    <NoWarn>$(NoWarn);NU1605</NoWarn>
+    <!-- Test with the library's FSharp.Core version. -->
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/FParsec-Pipes/FParsec-Pipes.fsproj
+++ b/FParsec-Pipes/FParsec-Pipes.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
     <Authors>Robert Peele</Authors>
+    <Description>A library for building FParsec parsers using pipeline operators.</Description>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/rspeele/FParsec-Pipes</PackageProjectUrl>
     <RepositoryUrl>https://github.com/rspeele/FParsec-Pipes</RepositoryUrl>

--- a/FParsec-Pipes/FParsec-Pipes.fsproj
+++ b/FParsec-Pipes/FParsec-Pipes.fsproj
@@ -1,14 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
     <Authors>Robert Peele</Authors>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/rspeele/FParsec-Pipes</PackageProjectUrl>
     <RepositoryUrl>https://github.com/rspeele/FParsec-Pipes</RepositoryUrl>
     <PackageTags>parser combinator f# fsharp c# csharp parsec fparsec pipe pipes</PackageTags>
-    <PackageReleaseNotes>Target .NET standard 2.0.</PackageReleaseNotes>
+    <PackageReleaseNotes>Target netstandard1.6 and net45</PackageReleaseNotes>
     <Copyright>Copyright 2016 Robert Peele</Copyright>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Version>1.1.0</Version>
+
+    <!-- The F# SDK will specify a random package version. We'd rather be specific. -->
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="4.2.3" />
     <PackageReference Include="FParsec" Version="1.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Hit a couple snags, of course.
 * MS Test SDK downgrades packages with a warning: https://github.com/Microsoft/vstest/issues/1764
 * F# SDK so helpfully substitutes it's own random version of FSharp.Core package.

Targeting F# core package 4.2.3, since 4.2.* is the lowest version supporting netstandard.
 
I also resurrected generation of XML doc files, they were in the 0.3.1 package.

Tests out good:

```
c:\projects\FParsec-Pipes>dotnet test FParsec-Pipes-Test -f netcoreapp2.0
Microsoft (R) Build Engine version 15.8.169+g1ccb72aefa for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restoring packages for c:\projects\FParsec-Pipes\FParsec-Pipes\FParsec-Pipes.fsproj...
  Restoring packages for c:\projects\FParsec-Pipes\FParsec-Pipes-Test\FParsec-Pipes-Test.fsproj...
  Generating MSBuild file c:\projects\FParsec-Pipes\FParsec-Pipes\obj\FParsec-Pipes.fsproj.nuget.g.props.
  Generating MSBuild file c:\projects\FParsec-Pipes\FParsec-Pipes\obj\FParsec-Pipes.fsproj.nuget.g.targets.
  Restore completed in 637.35 ms for c:\projects\FParsec-Pipes\FParsec-Pipes\FParsec-Pipes.fsproj.
  Generating MSBuild file c:\projects\FParsec-Pipes\FParsec-Pipes-Test\obj\FParsec-Pipes-Test.fsproj.nuget.g.props.
  Generating MSBuild file c:\projects\FParsec-Pipes\FParsec-Pipes-Test\obj\FParsec-Pipes-Test.fsproj.nuget.g.targets.
  Restore completed in 866.43 ms for c:\projects\FParsec-Pipes\FParsec-Pipes-Test\FParsec-Pipes-Test.fsproj.
Build started, please wait...
Build completed.

Test run for c:\projects\FParsec-Pipes\FParsec-Pipes-Test\bin\Debug\netcoreapp2.0\FParsec-Pipes-Test.dll(.NETCoreApp,Version=v2.0)
Microsoft (R) Test Execution Command Line Tool Version 15.8.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...

Total tests: 47. Passed: 47. Failed: 0. Skipped: 0.
Test Run Successful.
Test execution time: 0.9635 Seconds
```

```
c:\projects\FParsec-Pipes>dotnet test FParsec-Pipes-Test -f net45
Microsoft (R) Build Engine version 15.8.169+g1ccb72aefa for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 33.81 ms for c:\projects\FParsec-Pipes\FParsec-Pipes\FParsec-Pipes.fsproj.
  Restore completed in 31.35 ms for c:\projects\FParsec-Pipes\FParsec-Pipes-Test\FParsec-Pipes-Test.fsproj.
Build started, please wait...
Build completed.

Test run for c:\projects\FParsec-Pipes\FParsec-Pipes-Test\bin\Debug\net45\FParsec-Pipes-Test.exe(.NETFramework,Version=v4.5)
Microsoft (R) Test Execution Command Line Tool Version 15.8.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...

Total tests: 47. Passed: 47. Failed: 0. Skipped: 0.
Test Run Successful.
Test execution time: 1.2194 Seconds
```

```
c:\projects\FParsec-Pipes>dotnet test Examples.SQLite
Build started, please wait...
Build completed.

Test run for c:\projects\FParsec-Pipes\Examples.SQLite\bin\Debug\netcoreapp2.0\Examples.SQLite.dll(.NETCoreApp,Version=v2.0)
Microsoft (R) Test Execution Command Line Tool Version 15.8.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
Skipped  TestSqlFiles

Total tests: 11. Passed: 10. Failed: 0. Skipped: 1.
Test Run Successful.
Test execution time: 1.6925 Seconds
```

Release packaging (requires the SNK file)

```
c:\projects\FParsec-Pipes>sn -k ..\robert.peele.snk

Microsoft (R) .NET Framework Strong Name Utility  Version 4.0.30319.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Key pair written to ..\robert.peele.snk

c:\projects\FParsec-Pipes>dotnet pack FParsec-Pipes -c Release
Microsoft (R) Build Engine version 15.8.169+g1ccb72aefa for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 29.78 ms for c:\projects\FParsec-Pipes\FParsec-Pipes\FParsec-Pipes.fsproj.
  FParsec-Pipes -> c:\projects\FParsec-Pipes\FParsec-Pipes\bin\Release\net45\FParsec-Pipes.dll
  FParsec-Pipes -> c:\projects\FParsec-Pipes\FParsec-Pipes\bin\Release\netstandard1.6\FParsec-Pipes.dll
  Successfully created package 'c:\projects\FParsec-Pipes\FParsec-Pipes\bin\Release\FParsec-Pipes.1.1.0.nupkg'.
```

Make sure the right FSharp.Core version 4.2.3 is really used.

```
c:\projects\FParsec-Pipes>dotnet build FParsec-Pipes-Test -c Release -bl:build.binlog -v:n | grep 'FSharp.Core'
         -r:C:\Users\kkm\.nuget\packages\fsharp.core\4.2.3\lib\net45\FSharp.Core.dll
         -r:C:\Users\kkm\.nuget\packages\fsharp.core\4.2.3\lib\netstandard1.6\FSharp.Core.dll
         -r:C:\Users\kkm\.nuget\packages\fsharp.core\4.2.3\lib\net45\FSharp.Core.dll
         -r:C:\Users\kkm\.nuget\packages\fsharp.core\4.2.3\lib\netstandard1.6\FSharp.Core.dll
```

Package contents and dependencies look reasonable, too.

```xml
c:\projects\FParsec-Pipes>unzip -l FParsec-Pipes\bin\Release\FParsec-Pipes.1.1.0.nupkg
Archive:  FParsec-Pipes\bin\Release\FParsec-Pipes.1.1.0.nupkg
  Length      Date    Time    Name
---------  ---------- -----   ----
      507  2018-10-16 20:13   _rels/.rels
     1578  2018-10-16 20:13   FParsec-Pipes.nuspec
   200704  2018-10-17 03:13   lib/net45/FParsec-Pipes.dll
    12028  2018-10-17 03:13   lib/net45/FParsec-Pipes.xml
   201216  2018-10-17 03:13   lib/netstandard1.6/FParsec-Pipes.dll
    12028  2018-10-17 03:13   lib/netstandard1.6/FParsec-Pipes.xml
      528  2018-10-16 20:13   [Content_Types].xml
      683  2018-10-16 20:13   package/services/metadata/core-properties/a079646db21a4b81837eb9bd62131c5f.psmdcp
---------                     -------
   429272                     8 files

c:\projects\FParsec-Pipes>unzip -p FParsec-Pipes\bin\Release\FParsec-Pipes.1.1.0.nupkg FParsec-Pipes.nuspec
﻿<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
  <metadata>
    <id>FParsec-Pipes</id>
    <version>1.1.0</version>
    <authors>Robert Peele</authors>
    <owners>Robert Peele</owners>
    <requireLicenseAcceptance>false</requireLicenseAcceptance>
    <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
    <projectUrl>https://github.com/rspeele/FParsec-Pipes</projectUrl>
    <description>Package Description</description>
    <releaseNotes>Target netstandard1.6 and net45</releaseNotes>
    <copyright>Copyright 2016 Robert Peele</copyright>
    <tags>parser combinator f# fsharp c# csharp parsec fparsec pipe pipes</tags>
    <repository url="https://github.com/rspeele/FParsec-Pipes" />
    <dependencies>
      <group targetFramework=".NETFramework4.5">
        <dependency id="FParsec" version="1.0.3" exclude="Build,Analyzers" />
        <dependency id="FSharp.Core" version="4.2.3" exclude="Build,Analyzers" />
        <dependency id="System.ValueTuple" version="4.4.0" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard1.6">
        <dependency id="FParsec" version="1.0.3" exclude="Build,Analyzers" />
        <dependency id="FSharp.Core" version="4.2.3" exclude="Build,Analyzers" />
        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
        <dependency id="System.ValueTuple" version="4.4.0" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
</package>
```

Closes #9