### PR TITLE
Upgrade to .Net Standard 2.0

### DIFF
--- a/Examples.SQLite/Examples.SQLite.fsproj
+++ b/Examples.SQLite/Examples.SQLite.fsproj
@@ -58,7 +58,6 @@
     <Compile Include="AST.fs" />
     <Compile Include="SQLite.fs" />
     <Compile Include="Tests.fs" />
-    <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples.SQLite/Examples.SQLite.fsproj
+++ b/Examples.SQLite/Examples.SQLite.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -62,15 +62,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="FParsec" Version="1.0.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\FParsec-Pipes\FParsec-Pipes.fsproj" />
   </ItemGroup>
 
-  <ItemGroup />
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="4.6.2" />
+  </ItemGroup>
 
 </Project>

--- a/Examples.SQLite/Program.fs
+++ b/Examples.SQLite/Program.fs
@@ -1,1 +1,0 @@
-module Program = let [<EntryPoint>] main _ = 0

--- a/FParsec-Pipes-Test/FParsec-Pipes-Test.fsproj
+++ b/FParsec-Pipes-Test/FParsec-Pipes-Test.fsproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>FParsec_Pipes_Test</RootNamespace>
 
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FParsec-Pipes-Test/FParsec-Pipes-Test.fsproj
+++ b/FParsec-Pipes-Test/FParsec-Pipes-Test.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <RootNamespace>FParsec_Pipes_Test</RootNamespace>
 

--- a/FParsec-Pipes-Test/FParsec-Pipes-Test.fsproj
+++ b/FParsec-Pipes-Test/FParsec-Pipes-Test.fsproj
@@ -22,7 +22,6 @@
     <Compile Include="TestIgnoredInputs.fs" />
     <Compile Include="TestMany.fs" />
     <Compile Include="TestPrecedence.fs" />
-    <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FParsec-Pipes-Test/Program.fs
+++ b/FParsec-Pipes-Test/Program.fs
@@ -1,1 +1,0 @@
-module Program = let [<EntryPoint>] main _ = 0

--- a/FParsec-Pipes/FParsec-Pipes.fsproj
+++ b/FParsec-Pipes/FParsec-Pipes.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Robert Peele</Authors>
     <Description>A library for building FParsec parsers using pipeline operators.</Description>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>

--- a/FParsec-Pipes/FParsec-Pipes.fsproj
+++ b/FParsec-Pipes/FParsec-Pipes.fsproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Authors>Robert Peele</Authors>
     <Description>A library for building FParsec parsers using pipeline operators.</Description>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/rspeele/FParsec-Pipes</PackageProjectUrl>
     <RepositoryUrl>https://github.com/rspeele/FParsec-Pipes</RepositoryUrl>
     <PackageTags>parser combinator f# fsharp c# csharp parsec fparsec pipe pipes</PackageTags>
-    <PackageReleaseNotes>Target netstandard1.6 and net45</PackageReleaseNotes>
+    <PackageReleaseNotes>Target netstandard2.0</PackageReleaseNotes>
     <Copyright>Copyright 2016 Robert Peele</Copyright>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>1.1.1</Version>
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.2.3" />
+    <PackageReference Include="FSharp.Core" Version="4.6.2" />
     <PackageReference Include="FParsec" Version="1.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
* Upgraded/removed project to .Net Standard 2.0 for the core library. 
* For tests, due to sub-dependency (MS testing framework) requirements used .Net core
* Removed `Program.fs` for tests projects.
* Also upgraded the package references and ran the tests.
* Upgraded FSharp.Core to 4.6.2